### PR TITLE
Handle InvalidDataException when opening diagram package

### DIFF
--- a/src/Dsl/GeneratedCode/SerializationHelperAllDiagrams.cs
+++ b/src/Dsl/GeneratedCode/SerializationHelperAllDiagrams.cs
@@ -363,7 +363,7 @@ namespace Sawczyn.EFDesigner.EFModel
 	               }
 	            }
 	         }
-	         catch (FileFormatException)
+	         catch (Exception ex) when (ex is InvalidDataException || ex is FileFormatException) 
 	         {
 	            XDocument xmlDocument = XDocument.Load(diagramsFileName);
 	

--- a/src/Dsl/GeneratedCode/SerializationHelperAllDiagrams.tt
+++ b/src/Dsl/GeneratedCode/SerializationHelperAllDiagrams.tt
@@ -416,7 +416,7 @@ public abstract partial class <#= dslName #>SerializationHelperBase
                }
             }
          }
-         catch (FileFormatException)
+         catch (Exception ex) when (ex is InvalidDataException || ex is FileFormatException) 
          {
             XDocument xmlDocument = XDocument.Load(diagramsFileName);
 


### PR DESCRIPTION
Problem

On some Visual Studio 2026 installations, reopening .diagramx / .efmodel files fails with:
“Cannot access Central Directory record”
ObjectDisposedException involving MarshallingWindowFrame

Investigation showed that System.IO.Packaging.Package.Open() throws InvalidDataException (instead of FileFormatException) when the file is plain XML rather than a package. The existing code only handled FileFormatException, so the XML fallback was never reached.
The same files open correctly in VS 2022, indicating a runtime behavior change rather than file corruption.

Fix
Treat InvalidDataException the same as FileFormatException and fall back to XML loading.
This restores the ability to reopen existing models across VS versions without affecting valid package files.
Fixes issue #112 